### PR TITLE
opening directories recursively

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,9 @@ You can use ``rmate --help`` to see the usage
                        TextMate selection strings can be used
       -m, --name NAME  The display name shown in TextMate
       -t, --type TYPE  Treat file as having TYPE
+      -n, --new        Open in a new window (Sublime Text)
       -f, --force      Open even if the file is not writable
+      -r, --recursive  Open directories recursively
       -v, --verbose    Verbose logging messages
       -h, --help       Show this help and exit
           --version    Show version and exit

--- a/bin/rmate
+++ b/bin/rmate
@@ -161,7 +161,8 @@ class Settings:
 		      "                   TextMate selection strings can be used\n"
 		      "  -m, --name NAME  The display name shown in TextMate\n"
 		      "  -t, --type TYPE  Treat file as having TYPE\n"
-		      "  -f, --force      Open even if the file is not wratable\n"
+		      "  -n, --new        Open in a new window (Sublime Text)\n"
+		      "  -f, --force      Open even if the file is not writable\n"
 		      "  -v, --verbose    Verbose logging messages\n"
 		      "  -h, --help       Show this help and exit\n"
 		      "      --version    Show version and exit\n\n"
@@ -179,7 +180,8 @@ class Settings:
 
 	def parse_cli_options(self):
 		try:
-			optlist, args = getopt.gnu_getopt(sys.argv[1:], 'hp:wl:m:t:fv', ['host=', 'port=', 'wait', 'no-wait', 'line=', 'name=', 'type=', 'force', 'verbose', 'help', 'version'])
+			optlist, args = getopt.gnu_getopt(sys.argv[1:], 'hp:wl:m:t:nfv', ['host=', 'port=', 'wait', 'no-wait', 'line=',
+				'name=', 'type=', 'new', 'force', 'verbose', 'help', 'version'])
 		except getopt.GetoptError:
 			self.usage()
 			sys.exit(2)
@@ -194,6 +196,7 @@ class Settings:
 			elif name in ('-l', '--line'):    self.lines.append(value)
 			elif name in ('-m', '--name'):    self.names.append(value)
 			elif name in ('-t', '--type'):    self.types.append(value)
+			elif name in ('-n', '--new'):     self.new = True
 			elif name in ('-f', '--force'):   self.force = True
 			elif name in ('-v', '--verbose'): self.verbose = True
 
@@ -276,6 +279,9 @@ def main():
 
 		cmd["data-on-save"] = 'yes'
 		cmd["re-activate"] = 'yes'
+		if settings.new:
+			cmd["new"] = 'yes'
+			settings.new = False
 		cmd["token"] = path
 		if path == '-':
 			cmd.read_stdin()

--- a/bin/rmate
+++ b/bin/rmate
@@ -133,11 +133,13 @@ class Settings:
 		self.port    = 52698
 		self.wait    = False
 		self.force   = False
+		self.new     = False
 		self.verbose = False
 		self.lines   = []
 		self.names   = []
 		self.types   = []
 		self.files   = []
+		self.ignore  = []
 		self.tmpFile = None
 		self.recursive = False
 
@@ -179,6 +181,7 @@ class Settings:
 			sys.stderr.write('Could not read settings from disk.\n')
 		if config.has_option('NOSECTION', 'host'): self.host = config.get('NOSECTION', 'host')
 		if config.has_option('NOSECTION', 'port'): self.port = config.get('NOSECTION', 'port')
+		if config.has_option('NOSECTION', 'ignore'): self.ignore = config.get('NOSECTION', 'ignore').split()
 
 	def parse_cli_options(self):
 		try:
@@ -263,9 +266,15 @@ def main():
 			sys.stderr.write('Reading from stdin, press ^D to stop\n')
 		elif os.path.isdir(path):
 			if settings.recursive:
+				if any(pattern in path for pattern in settings.ignore):
+					log("Ignoring folder %s" % path)
+					continue
 				log("Opening %s recursively" % path)
 				for (dirpath, dirnames, filenames) in os.walk(path):
-					settings.files.extend(os.path.join(dirpath, dirname) for dirname in dirnames if dirname[0] != '.')
+					for dirname in dirnames[:]:
+						# prune search
+						if any(pattern in dirname for pattern in settings.ignore) or dirname[0] == '.':
+							dirnames.remove(dirname)
 					settings.files.extend(os.path.join(dirpath, filename) for filename in filenames if filename[0] != '.')
 			else:
 				sys.stderr.write("'%s' is a directory! Use -r/--recursive to open recursively.\n" % path)
@@ -276,6 +285,9 @@ def main():
 			else:
 				sys.stderr.write("File %s is not writable! Use -f/--force to open anyway.\n" % path)
 				continue
+		elif any(pattern in path for pattern in settings.ignore):
+			log("Ignoring file %s" % path)
+			continue
 
 		cmd = Command("open")
 		if   len(settings.names) > idx: cmd['display-name'] = settings.names[idx]

--- a/bin/rmate
+++ b/bin/rmate
@@ -139,6 +139,7 @@ class Settings:
 		self.types   = []
 		self.files   = []
 		self.tmpFile = None
+		self.recursive = False
 
 		self.read_disk_settings()
 
@@ -163,6 +164,7 @@ class Settings:
 		      "  -t, --type TYPE  Treat file as having TYPE\n"
 		      "  -n, --new        Open in a new window (Sublime Text)\n"
 		      "  -f, --force      Open even if the file is not writable\n"
+		      "  -r, --recursive  Open directories recursively\n"
 		      "  -v, --verbose    Verbose logging messages\n"
 		      "  -h, --help       Show this help and exit\n"
 		      "      --version    Show version and exit\n\n"
@@ -180,25 +182,26 @@ class Settings:
 
 	def parse_cli_options(self):
 		try:
-			optlist, args = getopt.gnu_getopt(sys.argv[1:], 'hp:wl:m:t:nfv', ['host=', 'port=', 'wait', 'no-wait', 'line=',
-				'name=', 'type=', 'new', 'force', 'verbose', 'help', 'version'])
+			optlist, args = getopt.gnu_getopt(sys.argv[1:], 'hp:wl:m:t:nfrv', ['host=', 'port=', 'wait', 'no-wait', 'line=',
+				'name=', 'type=', 'new', 'force', 'recursive', 'verbose', 'help', 'version'])
 		except getopt.GetoptError:
 			self.usage()
 			sys.exit(2)
 
 		for name, value in optlist:
-			if name == '--version':           print(VERSION_STRING); sys.exit()
-			elif name in ('-h', '--help'):    self.usage(); sys.exit()
-			elif name == '--host':            self.host = value
-			elif name in ('-p', '--port'):    self.port = int(value)
-			elif name in ('-w', '--wait'):    self.wait = True
-			elif name == '--no-wait':         self.wait = False
-			elif name in ('-l', '--line'):    self.lines.append(value)
-			elif name in ('-m', '--name'):    self.names.append(value)
-			elif name in ('-t', '--type'):    self.types.append(value)
-			elif name in ('-n', '--new'):     self.new = True
-			elif name in ('-f', '--force'):   self.force = True
-			elif name in ('-v', '--verbose'): self.verbose = True
+			if name == '--version':               print(VERSION_STRING); sys.exit()
+			elif name in ('-h', '--help'):        self.usage(); sys.exit()
+			elif name == '--host':                self.host = value
+			elif name in ('-p', '--port'):        self.port = int(value)
+			elif name in ('-w', '--wait'):        self.wait = True
+			elif name == '--no-wait':             self.wait = False
+			elif name in ('-l', '--line'):        self.lines.append(value)
+			elif name in ('-m', '--name'):        self.names.append(value)
+			elif name in ('-t', '--type'):        self.types.append(value)
+			elif name in ('-n', '--new'):         self.new = True
+			elif name in ('-f', '--force'):       self.force = True
+			elif name in ('-r', '--recursive'):   self.recursive = True
+			elif name in ('-v', '--verbose'):     self.verbose = True
 
 		if '-' in sys.argv[1:] and '-' not in args: args.append('-')
 		self.files = args
@@ -259,7 +262,13 @@ def main():
 		elif path == '-' and sys.stdin.isatty():
 			sys.stderr.write('Reading from stdin, press ^D to stop\n')
 		elif os.path.isdir(path):
-			sys.stderr.write("'%s' is a directory!\n" % path)
+			if settings.recursive:
+				log("Opening %s recursively" % path)
+				for (dirpath, dirnames, filenames) in os.walk(path):
+					settings.files.extend(os.path.join(dirpath, dirname) for dirname in dirnames if dirname[0] != '.')
+					settings.files.extend(os.path.join(dirpath, filename) for filename in filenames if filename[0] != '.')
+			else:
+				sys.stderr.write("'%s' is a directory! Use -r/--recursive to open recursively.\n" % path)
 			continue
 		elif os.path.isfile(path) and not os.access(path, os.W_OK):
 			if settings.force:


### PR DESCRIPTION
I added a `-r` option to open files inside a directory (recursively). This is inspired by the similar feature in the BASH version of rmate. It also contains the `-n` flag to open a new Sublime window.

More explanation here: https://github.com/randy3k/RemoteSubl/issues/19